### PR TITLE
pin torchvision version

### DIFF
--- a/PyTorch/Dockerfile
+++ b/PyTorch/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update --fix-missing && \
 RUN echo "\n\nInstalling mamba ..." && \
     conda install mamba -n base -c conda-forge && \
     echo "\n\nInstalling packages from conda-forge using mamba ..." && \
-    mamba install -y -c conda-forge dask distributed gpyopt ipympl ipywidgets jax jupyterlab \
+    mamba install -y -c pytorch -c conda-forge torchvision=0.10.0 cudatoolkit=11.1 dask distributed gpyopt ipympl ipywidgets jax jupyterlab \
       matplotlib mlflow nodejs notebook numba pandas pydot pygpu PyHamcrest pytables pytest \
       scikit-image scikit-learn tensorboardx uproot uproot-methods widgetsnbextension xrootd=5.2.0 && \
     jupyter labextension install @jupyter-widgets/jupyterlab-manager && \


### PR DESCRIPTION
Recently (past ~two weeks), we noticed that our derived PyTorch container could no longer access GPUs: `torch.cuda.is_available()` returned `False` even when GPUs were available, and the base image from PyTorch did not have this problem.

We determined that Conda/Mamba was "upgrading" torchvision and, in the process, changing from the GPU version of the package to the CPU version. Following https://stackoverflow.com/questions/69204737/torch-cuda-is-available-returns-false-why to specify the exact versions of torchvision, cudatoolkit (to get the GPU package) and the pytorch channel is the only way we could find to prevent this. (`--freeze-installed`, Conda's pinned package list, etc. were ineffective.)